### PR TITLE
Transition to qt6

### DIFF
--- a/barcode/upc.py
+++ b/barcode/upc.py
@@ -11,6 +11,7 @@ __docformat__ = 'restructuredtext en'
 from barcode.base import Barcode
 from barcode.charsets import upc as _upc
 from barcode.errors import *
+from functools import reduce
 
 class UniversalProductCodeA(Barcode):
     """Initializes new UPC-A barcode.

--- a/gui/editor_window.py
+++ b/gui/editor_window.py
@@ -2,9 +2,9 @@
 import logging
 import pickle
 
-from PyQt5.QtCore import Qt, QRect, QPoint, QMargins, QModelIndex
-from PyQt5.QtGui import QPixmap, QImage, QPainter, QColor, QIcon, QBitmap
-from PyQt5.QtWidgets import QApplication, QVBoxLayout, QPushButton, QLabel, QFileDialog, QHBoxLayout, \
+from PyQt6.QtCore import Qt, QRect, QPoint, QMargins, QModelIndex
+from PyQt6.QtGui import QPixmap, QImage, QPainter, QColor, QIcon, QBitmap
+from PyQt6.QtWidgets import QApplication, QVBoxLayout, QPushButton, QLabel, QFileDialog, QHBoxLayout, \
     QGroupBox, QMessageBox, QMainWindow, QScrollArea, QSizePolicy
 
 from app import APP_NAME, APP_VERSION
@@ -72,7 +72,7 @@ class EditorWindow(QMainWindow):
         root = QVBoxLayout()
         items_layout = QHBoxLayout()
         items_layout.addWidget(sources)
-        items_layout.setAlignment(Qt.AlignLeft)
+        items_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
         sources.item_selected.connect(self.selected_item_changed)
         sources.items_changed.connect(self.items_changed)
@@ -114,14 +114,14 @@ class EditorWindow(QMainWindow):
         preview_container.setFixedHeight(USABLE_HEIGHT + 2)
         preview_wrapper.setContentsMargins(0, 0, 0, 0)
 
-        preview_wrapper.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        preview_wrapper.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        preview_wrapper.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
+        preview_wrapper.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         preview_wrapper.setWidgetResizable(True)
         layout.addWidget(preview_wrapper)
 
         # layout.addWidget(self.save_image_button)
         group.setLayout(layout)
-        group.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed))
+        group.setSizePolicy(QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed))
 
         root.addWidget(group)
 
@@ -312,7 +312,7 @@ class EditorWindow(QMainWindow):
         item_renders = []
         item_preview_offsets = []
         width_needed = 0
-        bg_color = Qt.white
+        bg_color = Qt.GlobalColor.white
 
         items = self.sources.items.items
         for i, item in enumerate(items):
@@ -326,7 +326,7 @@ class EditorWindow(QMainWindow):
             margins = item.get_margins()
             src_rect = render.rect().marginsAdded(QMargins(margins.left, 0, margins.right, 0))
             sz = src_rect.size()
-            dst_rect = QRect(QPoint(), sz.scaled(sz * margins.scale, Qt.KeepAspectRatio))
+            dst_rect = QRect(QPoint(), sz.scaled(sz * margins.scale, Qt.AspectRatioMode.KeepAspectRatio))
             # dst_rect.marginsAdded(margins.getQMargins())
             dst_rect.translate(width_needed, margins.vert + ((USABLE_HEIGHT - dst_rect.height()) // 2))
             invert = self.needs_invert and item.get_type() in ['Image', 'Barcode', 'QRCode']
@@ -335,19 +335,19 @@ class EditorWindow(QMainWindow):
             item_preview_offsets.append(width_needed)
 
         x = 0
-        image = QImage(width_needed, USABLE_HEIGHT, QImage.Format_Mono)
+        image = QImage(width_needed, USABLE_HEIGHT, QImage.Format.Format_Mono)
         image.fill(bg_color)
         painter = QPainter(image)
-        painter.setBackgroundMode(Qt.OpaqueMode)
+        painter.setBackgroundMode(Qt.BGMode.OpaqueMode)
         for render, dst_rect, src_rect, invert in iter(item_renders):
             fill_rect = QRect(dst_rect.left(), 0, dst_rect.width(), USABLE_HEIGHT)
             painter.fillRect(fill_rect, bg_color)
             if invert:
-                painter.setBackground(Qt.black)
-                painter.setPen(Qt.white)
+                painter.setBackground(Qt.GlobalColor.black)
+                painter.setPen(Qt.GlobalColor.white)
             else:
-                painter.setBackground(Qt.white)
-                painter.setPen(Qt.black)
+                painter.setBackground(Qt.GlobalColor.white)
+                painter.setPen(Qt.GlobalColor.black)
             painter.drawPixmap(dst_rect, render, src_rect)
             x += fill_rect.width()
         painter.end()

--- a/gui/editor_window.py
+++ b/gui/editor_window.py
@@ -319,6 +319,7 @@ class EditorWindow(QMainWindow):
             render = QBitmap(item.render())
             render_error = item.get_render_error()
             if render_error is not None:
+                print(render_error)
                 continue
             # TODO: Decide how to present this to the user:
             #     QMessageBox.warning(self, 'Failed to render item', 'Failed to render item:\n' + str(render_error))

--- a/gui/editor_window.py
+++ b/gui/editor_window.py
@@ -327,7 +327,7 @@ class EditorWindow(QMainWindow):
             sz = src_rect.size()
             dst_rect = QRect(QPoint(), sz.scaled(sz * margins.scale, Qt.KeepAspectRatio))
             # dst_rect.marginsAdded(margins.getQMargins())
-            dst_rect.translate(width_needed, margins.vert + ((USABLE_HEIGHT - dst_rect.height()) / 2))
+            dst_rect.translate(width_needed, margins.vert + ((USABLE_HEIGHT - dst_rect.height()) // 2))
             invert = self.needs_invert and item.get_type() in ['Image', 'Barcode', 'QRCode']
             item_renders.append((render, dst_rect, src_rect, invert))
             width_needed += dst_rect.width()

--- a/gui/item_view.py
+++ b/gui/item_view.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import pyqtSignal, Qt, QModelIndex
-from PyQt5.QtGui import QDragEnterEvent, QDropEvent, QStandardItemModel
-from PyQt5.QtWidgets import QTreeView, QWidget, QTableView, QAbstractItemView, QHeaderView
+from PyQt6.QtCore import pyqtSignal, Qt, QModelIndex
+from PyQt6.QtGui import QDragEnterEvent, QDropEvent, QStandardItemModel
+from PyQt6.QtWidgets import QTreeView, QWidget, QTableView, QAbstractItemView, QHeaderView
 from typing import *
 
 from .printables_model import PrintablesModel
@@ -24,30 +24,30 @@ class ItemView(QTableView):
         # self.setDefaultDropAction(Qt.MoveAction)
         # self.setDragDropMode(QTreeView.InternalMove)
         # self.setItemsExpandable(False)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
 
         self.setDragDropOverwriteMode(False)
         self.verticalHeader().hide()
-        self.setEditTriggers(QAbstractItemView.DoubleClicked)
+        self.setEditTriggers(QAbstractItemView.EditTrigger.DoubleClicked)
         # self.setDragDropMode(QAbstractItemView.InternalMove)
-        self.setDragDropMode(QAbstractItemView.InternalMove)
+        self.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
         # self.row
 
         header = self.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(1, QHeaderView.Stretch)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
 
     def item_from_index(self, index):
         return self.model().data(index)
 
     def dragEnterEvent(self, e: QDragEnterEvent) -> None:
-        self.draggedItem = self.indexAt(e.pos())
-        e.setDropAction(Qt.MoveAction)
+        self.draggedItem = self.indexAt(e.position().toPoint())
+        e.setDropAction(Qt.DropAction.MoveAction)
         super().dragEnterEvent(e)
 
     def dropEvent(self, e: QDropEvent) -> None:
-        dropped_index = self.indexAt(e.pos())
+        dropped_index = self.indexAt(e.position().toPoint())
         if not dropped_index.isValid():
             return
 

--- a/gui/log_console.py
+++ b/gui/log_console.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
 
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QTextEdit, QVBoxLayout, QWidget, QDialog, QPushButton
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import QTextEdit, QVBoxLayout, QWidget, QDialog, QPushButton
 
 
 class LogConsole(QTextEdit):
@@ -10,7 +10,7 @@ class LogConsole(QTextEdit):
         super().__init__(parent)
         self.setReadOnly(True)
         font = QFont('Fira')
-        font.setStyleHint(QFont.Monospace, QFont.PreferDefault)
+        font.setStyleHint(QFont.StyleHint.Monospace, QFont.StyleStrategy.PreferDefault)
         if hasattr(font, 'setFamilies'):
             font.setFamilies(['Fira', 'Source Code Pro', 'Monaco', 'Consolas', 'Monospaced', 'Courier'])
         self.setFont(font)

--- a/gui/preview_image.py
+++ b/gui/preview_image.py
@@ -1,8 +1,8 @@
 from typing import Optional, List, Tuple
 
-from PyQt5.QtCore import pyqtSignal, QRect, Qt
-from PyQt5.QtGui import QPainter, QImage, QPixmap, QColor, QPalette, QBitmap, QRegion
-from PyQt5.QtWidgets import QLabel, QWidget
+from PyQt6.QtCore import pyqtSignal, QRect, Qt
+from PyQt6.QtGui import QPainter, QImage, QPixmap, QColor, QPalette, QBitmap, QRegion
+from PyQt6.QtWidgets import QLabel, QWidget
 from qasync import QtGui
 
 from gui.types import Color
@@ -17,8 +17,8 @@ class PreviewImage(QLabel):
         self.selected_index = -1
         self.item_offsets: List[int] = []
         self.setFixedHeight(USABLE_HEIGHT + 2)
-        self.fg_color = Qt.black
-        self.bg_color = Qt.white
+        self.fg_color = Qt.GlobalColor.black
+        self.bg_color = Qt.GlobalColor.white
         self.preview_bitmap = QPixmap()
 
     def update_colors(self, fg: Color, bg: Color, repaint=True):
@@ -50,13 +50,13 @@ class PreviewImage(QLabel):
         for index, offset in enumerate(self.item_offsets):
             select_rect.translate(select_rect.width(), 0)
             select_rect.setWidth(offset - select_rect.left())
-            color = palette.color(QPalette.Highlight if self.selected_index == index else QPalette.Background)
+            color = palette.color(QPalette.ColorRole.Highlight if self.selected_index == index else QPalette.ColorRole.Window)
             painter.fillRect(select_rect, color)
 
     def setPixmap(self, a0: QtGui.QPixmap) -> None:
         self.preview_bitmap = QBitmap(a0)
-        img = QImage(a0.width(), a0.height() + 4, QImage.Format_RGB32)
-        img.fill(self.palette().color(QPalette.Background))
+        img = QImage(a0.width(), a0.height() + 4, QImage.Format.Format_RGB32)
+        img.fill(self.palette().color(QPalette.ColorRole.Window))
         if a0.width() > 0:
             with QPainter(img) as painter:
                 self.draw_preview(painter)
@@ -65,13 +65,13 @@ class PreviewImage(QLabel):
         self.repaint()
 
     def draw_preview(self, painter: QPainter):
-        painter.setBackgroundMode(Qt.OpaqueMode)
+        painter.setBackgroundMode(Qt.BGMode.OpaqueMode)
         painter.setBackground(self.bg_color)
         painter.setPen(self.fg_color)
         painter.drawPixmap(0, 0, self.preview_bitmap)
 
     def mousePressEvent(self, ev: QtGui.QMouseEvent) -> None:
-        x = ev.x()
+        x = ev.pos().x()
         for index, offset in enumerate(self.item_offsets):
             if x < offset:
                 self.preview_item_clicked.emit(index)

--- a/gui/printables_model.py
+++ b/gui/printables_model.py
@@ -2,8 +2,8 @@ import logging
 from enum import Enum
 from typing import *
 
-from PyQt5.QtCore import Qt, QAbstractItemModel, QModelIndex, QVariant
-from PyQt5.QtWidgets import QWidget
+from PyQt6.QtCore import Qt, QAbstractItemModel, QModelIndex, QVariant
+from PyQt6.QtWidgets import QWidget
 
 from printables.printable import Printable
 PrintableData = Union[QVariant, Printable]
@@ -40,20 +40,20 @@ class PrintablesModel(QAbstractItemModel):
     def hasChildren(self, parent: QModelIndex = ...) -> bool:
         return False
 
-    def setData(self, index: QModelIndex, value: PrintableData, role: Qt.ItemDataRole = Qt.EditRole) -> bool:
+    def setData(self, index: QModelIndex, value: PrintableData, role: Qt.ItemDataRole = Qt.ItemDataRole.EditRole) -> bool:
         return False
         # item = self.items[index.row()]
 
-    def data(self, index: QModelIndex, role: Qt.ItemDataRole = Qt.DisplayRole) -> Optional[PrintableData]:
+    def data(self, index: QModelIndex, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole) -> Optional[PrintableData]:
         if not index.isValid():
             return None
         item: Printable = index.internalPointer()
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             if index.column() == 0:
                 return item.get_type()
             else:
                 return item.get_name()
-        if role == Qt.DecorationRole:
+        if role == Qt.ItemDataRole.DecorationRole:
             if index.column() == 0:
                 return item.get_icon()
             elif index.column() == 1:
@@ -61,15 +61,15 @@ class PrintablesModel(QAbstractItemModel):
                 if re is not None:
                     return Printable.get_error_icon()
 
-        if role == Qt.EditRole:
+        if role == Qt.ItemDataRole.EditRole:
             if index.column() == 1:
                 return item.get_name()
         return None
 
-    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.DisplayRole) -> QVariant:
-        if role == Qt.DisplayRole:
+    def headerData(self, section: int, orientation: Qt.Orientation, role: Qt.ItemDataRole = Qt.ItemDataRole.DisplayRole) -> QVariant:
+        if role == Qt.ItemDataRole.DisplayRole:
             try:
-                if orientation == Qt.Vertical:
+                if orientation == Qt.Orientation.Vertical:
                     return QVariant(str(section))
                 else:
                     return PrintablesModel.Columns(section).name
@@ -110,15 +110,15 @@ class PrintablesModel(QAbstractItemModel):
 
         return False
 
-    def flags(self, index: QModelIndex) -> Qt.ItemFlags:
+    def flags(self, index: QModelIndex) -> Qt.ItemFlag:
         default = super().flags(index)
-        return Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled | int(default)
+        return Qt.ItemFlag.ItemIsDragEnabled | Qt.ItemFlag.ItemIsDropEnabled | Qt.ItemFlag(default)
 
-    def supportedDragActions(self) -> Qt.DropActions:
-        return Qt.MoveAction
+    def supportedDragActions(self) -> Qt.DropAction:
+        return Qt.DropAction.MoveAction
 
-    def supportedDropActions(self) -> Qt.DropActions:
-        return Qt.MoveAction
+    def supportedDropActions(self) -> Qt.DropAction:
+        return Qt.DropAction.MoveAction
 
     def clear(self):
         log.debug(f'Clearing {len(self.items)} items')

--- a/gui/printer_select.py
+++ b/gui/printer_select.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
-from PyQt5.QtCore import QDir, Qt
-from PyQt5.QtWidgets import QComboBox
+from PyQt6.QtCore import QDir, Qt
+from PyQt6.QtWidgets import QComboBox
 from qasync import asyncSlot
 
 from labelmaker.comms import list_printer_devices
@@ -24,11 +24,11 @@ class PrinterSelect(QComboBox):
 #            candidate = await self.update_devfs()
 
         #if candidate is not None:
-        index = self.findText('PT-P3', Qt.MatchContains)
+        index = self.findText('PT-P3', Qt.MatchFlag.MatchContains)
         if index > 0:
             self.setCurrentIndex(index)
 
-        self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.adjustSize()
         # self.setMinimumWidth(self.minimumSizeHint().width())
 
@@ -59,7 +59,7 @@ class PrinterSelect(QComboBox):
         # printer_select.setExpanded(dev_index, True)
         # model_proxy.setFilterWildcard('tty*')
 
-        for p in QDir('/dev').entryList(['tty*', 'rfcomm*'], QDir.System, QDir.Name):
+        for p in QDir('/dev').entryList(['tty*', 'rfcomm*'], QDir.Filter.System, QDir.SortFlag.Name):
             if p.startswith('tty.') or p.startswith('rfcomm'):
                 device = '/dev/' + p
 

--- a/gui/source_items.py
+++ b/gui/source_items.py
@@ -1,7 +1,7 @@
 import logging
 
-from PyQt5.QtCore import pyqtSignal, QModelIndex
-from PyQt5.QtWidgets import QGroupBox, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QMenu
+from PyQt6.QtCore import pyqtSignal, QModelIndex
+from PyQt6.QtWidgets import QGroupBox, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QMenu
 
 from printables.printable import Printable
 from .item_view import ItemView

--- a/gui/tape_select.py
+++ b/gui/tape_select.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
-from PyQt5.QtCore import QDir, Qt
-from PyQt5.QtWidgets import QComboBox
+from PyQt6.QtCore import QDir, Qt
+from PyQt6.QtWidgets import QComboBox
 from qasync import asyncSlot
 
 from labels import tapes
@@ -30,7 +30,7 @@ class TapeSelect(QComboBox):
             self.model.add_tape(label, fg, bg)
         self.setModel(self.model)
 
-        index = self.findText('TZe-231,', Qt.MatchStartsWith)
+        index = self.findText('TZe-231,', Qt.MatchFlag.MatchStartsWith)
         if index > 0:
             self.setCurrentIndex(index)
 

--- a/gui/top_menu.py
+++ b/gui/top_menu.py
@@ -1,5 +1,5 @@
-from PyQt5.QtGui import QKeySequence
-from PyQt5.QtWidgets import QMenuBar, QAction, QWidget
+from PyQt6.QtGui import QKeySequence, QAction
+from PyQt6.QtWidgets import QMenuBar, QWidget
 
 from util import *
 from app import *
@@ -12,7 +12,7 @@ class TopMenu(QMenuBar):
         super().__init__(parent)
 
         about = QAction('About ' + APP_NAME, self)
-        about.setMenuRole(QAction.AboutRole)
+        about.setMenuRole(QAction.MenuRole.AboutRole)
 
         prefs = QAction('&Preferences', self)
 

--- a/gui/types.py
+++ b/gui/types.py
@@ -1,8 +1,8 @@
 from enum import Enum, auto
 from typing import *
 
-from PyQt5.QtGui import QStandardItemModel, QStandardItem
-from PyQt5.QtWidgets import QWidget
+from PyQt6.QtGui import QStandardItemModel, QStandardItem
+from PyQt6.QtWidgets import QWidget
 
 Color = Tuple[int, int, int]
 

--- a/margins.py
+++ b/margins.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import QMargins
+from PyQt6.QtCore import QMargins
 
 
 class Margins:

--- a/print_thread.py
+++ b/print_thread.py
@@ -1,7 +1,7 @@
 import logging
 import traceback
 
-from PyQt5.QtCore import QThread, pyqtSignal
+from PyQt6.QtCore import QThread, pyqtSignal
 
 from labelmaker import LabelMaker, BUFFER_HEIGHT, PRINT_MARGIN
 

--- a/printables/barcode.py
+++ b/printables/barcode.py
@@ -4,6 +4,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPainter, QColor, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QLineEdit, QLabel, QComboBox, QCheckBox
 from barcode.writer import BaseWriter
+from barcode.errors import *
 
 from labelmaker import USABLE_HEIGHT
 from printables.printable import Printable, PrintableData
@@ -157,8 +158,9 @@ class Barcode(Printable):
         writer = BarcodeWriter(self.data.draw_label)
         self.render_error = None
         try:
+            print(d.code_type, d.text)
             img = barcode.generate(d.code_type, d.text, writer)
-        except Exception as x:
+        except (IllegalCharacterError, NumberOfDigitsError, WrongCountryCodeError) as x:
             self.render_error = x
             return QImage(0, 0, QImage.Format_ARGB32)
 

--- a/printables/barcode.py
+++ b/printables/barcode.py
@@ -1,8 +1,8 @@
 import barcode
-import traceback
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QImage, QPainter, QColor, QStandardItemModel, QStandardItem
-from PyQt5.QtWidgets import QLineEdit, QLabel, QComboBox, QCheckBox
+from typing import Optional
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QImage, QPainter, QColor, QStandardItemModel, QStandardItem
+from PyQt6.QtWidgets import QLineEdit, QLabel, QComboBox, QCheckBox
 from barcode.writer import BaseWriter
 from barcode.errors import *
 
@@ -92,7 +92,7 @@ class BarcodeWriter(BaseWriter):
         print('init', code)
         width, height = self.calculate_size(len(code[0]), len(code), self.dpi * 25)
         print(width, height)
-        image = QImage(width, USABLE_HEIGHT, QImage.Format_ARGB32)
+        image = QImage(width, USABLE_HEIGHT, QImage.Format.Format_ARGB32)
         image.fill(0xffffffff)
         self._painter = QPainter(image)
         self._image = image
@@ -119,14 +119,14 @@ class BarcodeWriter(BaseWriter):
         font = p.font()
         font.setPixelSize(self.text_size)
         p.setFont(font)
-        bounds = p.drawText(self._image.rect(), Qt.AlignBottom | Qt.AlignCenter, barcode_text)
+        bounds = p.drawText(self._image.rect(), Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignCenter, barcode_text)
         p.setBrush(QColor(0xffffffff))
         pen = p.pen()
-        p.setPen(Qt.NoPen)
+        p.setPen(Qt.PenStyle.NoPen)
         p.drawRect(bounds)
         p.setPen(pen)
 
-        p.drawText(self._image.rect(), Qt.AlignBottom | Qt.AlignCenter, barcode_text)
+        p.drawText(self._image.rect(), Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignCenter, barcode_text)
 
     def _finish(self):
         self._painter.end()
@@ -137,7 +137,7 @@ class BarcodeWriter(BaseWriter):
 
 
 class Barcode(Printable):
-    def __init__(self, data: BarcodeData = None):
+    def __init__(self, data: Optional[BarcodeData] = None):
         if data is None:
             data = BarcodeData()
         self.data = data
@@ -160,8 +160,8 @@ class Barcode(Printable):
         try:
             print(d.code_type, d.text)
             img = barcode.generate(d.code_type, d.text, writer)
-        except (IllegalCharacterError, NumberOfDigitsError, WrongCountryCodeError) as x:
+        except BarcodeError as x:
             self.render_error = x
-            return QImage(0, 0, QImage.Format_ARGB32)
+            return QImage(0, 0, QImage.Format.Format_ARGB32)
 
         return img

--- a/printables/barcode.py
+++ b/printables/barcode.py
@@ -1,4 +1,5 @@
 import barcode
+import traceback
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPainter, QColor, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QLineEdit, QLabel, QComboBox, QCheckBox
@@ -98,10 +99,10 @@ class BarcodeWriter(BaseWriter):
     def _create_module(self, xpos, _ypos, width, color):
         p = self._painter
         p.setBrush(QColor(color))
-        x1 = xpos * self.dpi
+        x1 = int(xpos * self.dpi)
         y1 = 0
-        x2 = width * self.dpi
-        y2 = USABLE_HEIGHT
+        x2 = int(width * self.dpi)
+        y2 = int(USABLE_HEIGHT)
         p.drawRect(x1, y1, x2, y2)
 
     def _create_text(self, _xpos, _ypos):

--- a/printables/image.py
+++ b/printables/image.py
@@ -1,9 +1,9 @@
 import os
 from typing import Optional
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QImage, QPainter, QPixmap, QIcon
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QLabel, QSlider, QHBoxLayout, QPushButton, QFileDialog
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QImage, QPainter, QPixmap, QIcon
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QLabel, QSlider, QHBoxLayout, QPushButton, QFileDialog
 
 from labelmaker import USABLE_HEIGHT
 from margins import Margins
@@ -15,7 +15,10 @@ class ImageData(PrintableData):
     source = ''
     threshold = 127
 
-    def __init__(self, image_source: str = None, threshold: int = 127, margins: Margins = None):
+    def __init__(
+            self, image_source: Optional[str] = None, 
+            threshold: int = 127, margins: Optional[Margins] = None
+    ):
         super().__init__(margins)
         self.source = image_source
         self.threshold = threshold
@@ -56,11 +59,11 @@ class ImagePropsEdit(PropsEdit):
         layout.addLayout(threshold)
         threshold.addWidget(QLabel('Threshold:'))
         thresh_value = QLabel(str(data.threshold))
-        thresh_value.setAlignment(Qt.AlignRight)
+        thresh_value.setAlignment(Qt.AlignmentFlag.AlignRight)
         threshold.addWidget(thresh_value)
         self.thresh_value = thresh_value
 
-        slider = QSlider(Qt.Horizontal, self)
+        slider = QSlider(Qt.Orientation.Horizontal, self)
         slider.setMinimum(1)
         slider.setMaximum(254)
         slider.setValue(data.threshold)
@@ -101,7 +104,7 @@ class ImagePropsEdit(PropsEdit):
 
 
 class Image(Printable):
-    def __init__(self, data: ImageData = None):
+    def __init__(self, data: Optional[ImageData] = None):
         super().__init__()
         if data is None:
             data = ImageData()
@@ -124,20 +127,20 @@ class Image(Printable):
         elif not os.path.isfile(self.data.source):
             return Image.get_generic_icon(False)
         img_source = QImage(self.data.source)
-        img = QImage(32, 32, QImage.Format_ARGB32)
+        img = QImage(32, 32, QImage.Format.Format_ARGB32)
         img.fill(0xffffffff)
 
         p = QPainter(img)
         p.drawRect(0, 0, 30, 30)
         if img_source.width() > img_source.height():
             scaled = img_source.scaledToWidth(32)
-            p.drawImage(0, 16 - (scaled.height() / 2), scaled)
+            p.drawImage(0, 16 - (scaled.height() // 2), scaled)
         else:
             scaled = img_source.scaledToHeight(32)
-            p.drawImage(16 - (scaled.width() / 2), 0, scaled)
+            p.drawImage(16 - (scaled.width() // 2), 0, scaled)
         p.end()
 
-        img = img.convertToFormat(QImage.Format_Mono)
+        img = img.convertToFormat(QImage.Format.Format_Mono)
 
         return QIcon(QPixmap.fromImage(img))
 
@@ -146,13 +149,13 @@ class Image(Printable):
         d = self.data
         if d.source is None:
             self.render_error = UserWarning('No image selected')
-            return QImage(0, USABLE_HEIGHT, QImage.Format_Mono)
+            return QImage(0, USABLE_HEIGHT, QImage.Format.Format_Mono)
         if not os.path.isfile(d.source):
             self.render_error = FileNotFoundError(f'Source file not found: {d.source}')
-            return QImage(0, USABLE_HEIGHT, QImage.Format_Mono)
+            return QImage(0, USABLE_HEIGHT, QImage.Format.Format_Mono)
         img_src = QImage(d.source)
         if img_src.hasAlphaChannel():
-            img = QImage(img_src.size(), QImage.Format_ARGB32)
+            img = QImage(img_src.size(), QImage.Format.Format_ARGB32)
             img.fill(0xffffffff)
             p = QPainter(img)
 
@@ -161,13 +164,13 @@ class Image(Printable):
         else:
             img = img_src
         # img.convertToFormat(QImage.Format_Mono)
-        img = img.scaledToHeight(USABLE_HEIGHT, Qt.FastTransformation)
+        img = img.scaledToHeight(USABLE_HEIGHT, Qt.TransformationMode.FastTransformation)
         rect = img.rect() # .marginsAdded(d.margins.getQMargins())
 
         max_x = img.width()
         max_y = USABLE_HEIGHT
 
-        bitmap = QImage(rect.width(), USABLE_HEIGHT, QImage.Format_Mono)
+        bitmap = QImage(rect.width(), USABLE_HEIGHT, QImage.Format.Format_Mono)
         for x in range(0, rect.width()):
             for y in range(0, USABLE_HEIGHT):
                 if x >= max_x or x <= 0 or y > max_y or y < 0:

--- a/printables/printable.py
+++ b/printables/printable.py
@@ -1,9 +1,9 @@
 import abc
 from typing import Optional
 import logging
-from PyQt5.QtCore import Qt, QLineF, QPointF
-from PyQt5.QtGui import QImage, QPainter, QColor, QIcon, QPixmap, QStandardItem, QPainterPath
-from PyQt5.QtWidgets import QLabel, QAction
+from PyQt6.QtCore import Qt, QLineF, QPointF
+from PyQt6.QtGui import QImage, QPainter, QColor, QIcon, QPixmap, QStandardItem, QPainterPath, QAction
+from PyQt6.QtWidgets import QLabel
 
 from margins import Margins
 
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class PrintableData:
     margins = Margins()
 
-    def __init__(self, margins: Margins = None):
+    def __init__(self, margins: Optional[Margins] = None):
         if margins is None:
             margins = Margins()
         self.margins = margins
@@ -65,7 +65,7 @@ class Printable(abc.ABC):
 
     @classmethod
     def get_generic_icon(cls, valid: bool = True) -> QIcon:
-        img = QImage(32, 32, QImage.Format_ARGB32)
+        img = QImage(32, 32, QImage.Format.Format_ARGB32)
         img.fill(QColor(200, 200, 200))
         with QPainter(img) as p:
             pen = p.pen()
@@ -78,14 +78,14 @@ class Printable(abc.ABC):
             font.setPixelSize(32)
             p.setFont(font)
 
-            p.drawText(img.rect(), Qt.AlignCenter, cls.get_letter())
+            p.drawText(img.rect(), Qt.AlignmentFlag.AlignCenter, cls.get_letter())
 
         return QIcon(QPixmap.fromImage(img))
 
     @classmethod
     def get_error_icon(cls) -> QIcon:
-        img = QImage(32, 32, QImage.Format_ARGB32)
-        img.fill(Qt.white)
+        img = QImage(32, 32, QImage.Format.Format_ARGB32)
+        img.fill(Qt.GlobalColor.white)
         with QPainter(img) as p:
             pen = p.pen()
             pen.setColor(QColor(0, 0, 0))
@@ -104,7 +104,7 @@ class Printable(abc.ABC):
             font.setPixelSize(26)
             p.setFont(font)
 
-            p.drawText(img.rect(), Qt.AlignCenter, '!')
+            p.drawText(img.rect(), Qt.AlignmentFlag.AlignCenter, '!')
 
         return QIcon(QPixmap.fromImage(img))
 

--- a/printables/propsedit.py
+++ b/printables/propsedit.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGroupBox
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QGroupBox
 
 from printables.printable import PrintableData
 from .qmargins_edit import QMarginsEdit

--- a/printables/qmargins_edit.py
+++ b/printables/qmargins_edit.py
@@ -1,7 +1,7 @@
 from typing import Type, TypeVar, Optional
 
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QSpinBox, QLabel, QWidget, QLayout, \
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QVBoxLayout, QHBoxLayout, QSpinBox, QLabel, QWidget, QLayout, \
     QAbstractSpinBox, QDoubleSpinBox
 
 from margins import Margins
@@ -41,7 +41,7 @@ class QMarginsEdit(QWidget):
             rows_layout.addLayout(margins_layout)
             
             self.scale = self.create_box(rows_layout, 'Scale:', QPercentSpinBox)
-            self.scale.setStepType(QAbstractSpinBox.AdaptiveDecimalStepType)
+            self.scale.setStepType(QAbstractSpinBox.StepType.AdaptiveDecimalStepType)
             self.setLayout(rows_layout)
 
             self.boxes = [self.margin_top, self.margin_left, self.margin_right]

--- a/printables/qrcode.py
+++ b/printables/qrcode.py
@@ -1,8 +1,8 @@
 import math
 
 import qrcode
-from PyQt5.QtGui import QImage, QPainter, QColor
-from PyQt5.QtWidgets import QLineEdit, QLabel
+from PyQt6.QtGui import QImage, QPainter, QColor
+from PyQt6.QtWidgets import QLineEdit, QLabel
 
 from labelmaker import USABLE_HEIGHT
 from printables.printable import PrintableData, Printable
@@ -58,7 +58,7 @@ class QrCode(Printable):
         qr.add_data(d.text)
         qr.make(fit=True)
 
-        img = QImage(USABLE_HEIGHT, USABLE_HEIGHT, QImage.Format_Mono)
+        img = QImage(USABLE_HEIGHT, USABLE_HEIGHT, QImage.Format.Format_Mono)
         img.fill(0xffffffff)
         with QPainter(img) as p:
 

--- a/printables/qrcode.py
+++ b/printables/qrcode.py
@@ -71,6 +71,6 @@ class QrCode(Printable):
             for r in range(modcount):
                 for c in range(modcount):
                     if qr.modules[r][c]:
-                        p.fillRect(padding + (r*M), padding + (c*M), M, M, black)
+                        p.fillRect(int(padding + (r*M)), int(padding + (c*M)), M, M, black)
 
         return img

--- a/printables/spacing.py
+++ b/printables/spacing.py
@@ -1,7 +1,8 @@
-from PyQt5.QtGui import QImage
-from PyQt5.QtWidgets import QLabel, QSpinBox
+from PyQt6.QtGui import QImage
+from PyQt6.QtWidgets import QLabel, QSpinBox
 
 from labelmaker import USABLE_HEIGHT
+from typing import Optional
 from margins import Margins
 from printables.printable import Printable, PrintableData
 from printables.propsedit import PropsEdit
@@ -51,7 +52,7 @@ class SpacingPropsEdit(PropsEdit):
 
 class Spacing(Printable):
 
-    def __init__(self, data: SpacingData = None):
+    def __init__(self, data: Optional[SpacingData] = None):
         if data is None:
             data = SpacingData()
         self.data = data
@@ -67,6 +68,6 @@ class Spacing(Printable):
 
         width = d.width
         print(width)
-        img = QImage(width, USABLE_HEIGHT, QImage.Format_ARGB32)
+        img = QImage(width, USABLE_HEIGHT, QImage.Format.Format_ARGB32)
         img.fill(0xffffffff)
         return img

--- a/printables/text.py
+++ b/printables/text.py
@@ -1,11 +1,12 @@
 import logging
 from copy import copy
 
-from PyQt5.QtCore import Qt, QMargins
-from PyQt5.QtGui import QFont, QImage, QPainter, QFontMetrics
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QLabel, QPushButton, QFontDialog, QHBoxLayout, QSizePolicy, \
+from PyQt6.QtCore import Qt, QMargins
+from PyQt6.QtGui import QFont, QImage, QPainter, QFontMetrics
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QLabel, QPushButton, QFontDialog, QHBoxLayout, QSizePolicy, \
     QFontComboBox, QGroupBox, QSpinBox, QCheckBox
 
+from typing import Optional
 from labelmaker import USABLE_HEIGHT
 from margins import Margins
 from printables.printable import Printable, PrintableData
@@ -17,13 +18,13 @@ log = logging.getLogger(__name__)
 
 class TextData(PrintableData):
 
-    def __init__(self, text='', font_string=None, margins: Margins = None):
+    def __init__(self, text='', font_string=None, margins: Optional[Margins] = None):
         super().__init__(margins)
         self.text = text
 
         if font_string is None:
             font = QFont()
-            font.setStyleHint(QFont.Helvetica)
+            font.setStyleHint(QFont.StyleHint.Helvetica)
             if hasattr(font, 'setFamily'):
                 font.setFamily('Helvetica Neue')
 
@@ -68,11 +69,11 @@ class TextPropsEdit(PropsEdit):
         self.layout.addWidget(self.edit_text)
 
         self.button_font = QPushButton(self.get_font_name())
-        self.button_font.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.button_font.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.button_font.clicked.connect(self.button_font_clicked)
 
         button_default = QPushButton('Set as default', self)
-        button_default.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        button_default.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         button_default.clicked.connect(self.default_clicked)
 
         font_layout = QVBoxLayout()
@@ -212,14 +213,14 @@ class Text(Printable):
         d = self.data
         font = QFont()
         font.fromString(d.font_string)
-        width = QFontMetrics(font).width(d.text)
+        width = QFontMetrics(font).horizontalAdvance(d.text)
         log.debug(f'Width: {width}, Font: {font}, Text: {d.text}')
-        img = QImage(width, USABLE_HEIGHT, QImage.Format_Mono)
+        img = QImage(width, USABLE_HEIGHT, QImage.Format.Format_Mono)
         img.fill(0xffffffff)
         p = QPainter(img)
         p.setFont(font)
         rect = img.rect() # .marginsRemoved(d.margins.getQMargins())
-        p.drawText(rect, Qt.AlignLeft | Qt.AlignHCenter, d.text)
+        p.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignHCenter, d.text)
         p.end()
         del p
         return img

--- a/pytouch3.py
+++ b/pytouch3.py
@@ -4,7 +4,7 @@ import sys
 import os.path as path
 from sys import argv
 
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication
 from qasync import QEventLoop
 
 from gui import EditorWindow

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pypng
 appdirs~=1.4.4
 pyyaml~=5.4.0
 qrcode~=6.1
-qasync~=0.13.0
+qasync~=0.23.0
 setuptools~=41.2.0
 altgraph~=0.17
 pybluez~=0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ qrcode~=6.1
 qasync~=0.13.0
 setuptools~=41.2.0
 altgraph~=0.17
+pybluez~=0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5>=5.12.0
+PyQt6>=6.3
 django-qrcode~=0.3
 pyserial~=3.4
 packbits~=0.6

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from util import *
 import app
 import site
 
-qt_plugin_root = site.getsitepackages()[1] + "\\PyQt5\\Qt\\plugins"
+qt_plugin_root = site.getsitepackages()[1] + "\\PyQt6\\Qt\\plugins"
 
 APP = 'pytouch3.py'
 data_files = [
@@ -18,7 +18,7 @@ data_files = [
 ]
 
 setup_requires = []
-requires = ['PyQt5', 'django-qrcode', 'pyserial', 'packbits', 'pypng', 'appdirs']
+requires = ['PyQt6', 'django-qrcode', 'pyserial', 'packbits', 'pypng', 'appdirs']
 kwargs = {}
 
 if is_mac:
@@ -54,9 +54,9 @@ setup(
         },
         'py2exe': {
             'includes': [
-                'PyQt5.sip',
-                'PyQt5.QtCore',
-                'PyQt5.QtGui'
+                'PyQt6.sip',
+                'PyQt6.QtCore',
+                'PyQt6.QtGui'
             ]
         }
     },


### PR DESCRIPTION
Translated the application to run with PyQt6 instead of Qt5 getting it into the modern age.

Especially the Wayland support in Linux (and probably a few elements in other OSes too) have improved significantly. 
The mayor changes were essentially to use `int` instead of `float` when rendering stuff and stating the enum types explicitly instead of using the global namespace.

I also improved a tiny bit on the error messages thrown, but it's almost insignificant.