### PR TITLE
Make LogConsole thread safe

### DIFF
--- a/gui/editor_window.py
+++ b/gui/editor_window.py
@@ -288,15 +288,14 @@ class EditorWindow(QMainWindow):
                 modal.log_message('Printing completed without any errors!\n')
             modal.enable_close()
 
+        
         log.info('Starting print thread...')
-        # modal.log_message(')
 
         print_device = self.printer_select.currentData()
 
         # print_device = self.printer_select.currentData(1)
         log.debug(f'Using device: {print_device}')
         self.print_thread = PrintThread(QImage(self.print_image), print_device)
-        # self.print_thread.log.connect(log)
         self.print_thread.done.connect(done)
 
         self.print_thread.start()

--- a/gui/log_console.py
+++ b/gui/log_console.py
@@ -1,11 +1,14 @@
 import logging
 from typing import Optional
 
+from PyQt5.QtCore import pyqtSignal, pyqtBoundSignal
 from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QTextEdit, QVBoxLayout, QWidget, QDialog, QPushButton
 
 
 class LogConsole(QTextEdit):
+    log_signal = pyqtSignal(str)
+
     def __init__(self, parent: Optional[QWidget]):
         super().__init__(parent)
         self.setReadOnly(True)
@@ -15,9 +18,14 @@ class LogConsole(QTextEdit):
             font.setFamilies(['Fira', 'Source Code Pro', 'Monaco', 'Consolas', 'Monospaced', 'Courier'])
         self.setFont(font)
 
-        logging.root.addHandler(LogConsoleHandler(self))
+        self.log_signal.connect(self.print_message)
+        
+        logging.root.addHandler(LogConsoleHandler(self.log_signal))
         logging.root.setLevel(logging.INFO)
 
+    def print_message(self, message: str):
+        self.textCursor().insertText(message + "\n")
+        self.ensureCursorVisible()
 
     # def fmt_log(message):
     #     now = datetime.datetime.now()
@@ -48,17 +56,16 @@ class LogConsoleModal(QDialog):
         self.close_button.setDisabled(False)
 
     def log_message(self, message: str):
-        self.log_console.insertPlainText(message + "\n")
+        self.log_console.log_signal.emit(message)
 
     def on_close(self):
         self.close()
 
 
 class LogConsoleHandler(logging.Handler):
-    def __init__(self, log_console: LogConsole):
+    def __init__(self, log_handler: pyqtBoundSignal):
         super(LogConsoleHandler, self).__init__()
-        self.log_console = log_console
+        self.log_handler = log_handler
 
     def emit(self, record: logging.LogRecord):
-        self.log_console.insertPlainText(record.getMessage() + "\n")
-        self.log_console.ensureCursorVisible()
+        self.log_handler.emit(record.getMessage())


### PR DESCRIPTION
Previously the whole application core dumped after a finished print or
when a log message was emited from the main thread after the printing
thread wrote into it.

One can only speculate what exactly happened here, but a plausible
explanation seems to be that when the printing thread wrote into the
window as a copy to write was done as the window was accessed.
Essentially moving the ownership into the printing thread. The moment
the original main thread tried to access the window again (e.g. after
closing it, writing to it, ...) everything came down as the state
didn't represent the expected state anymore.

Introducing a qt signal (which are thread safe) solves this problem as
the text field is only accessed now from the thread that created the
window.