### PR TITLE
Add cli

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,2 @@
+from .arguments import get_parser
+from .cli_print import CliPrint

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -77,6 +77,8 @@ def get_parser():
     print_modes = cli.add_subparsers(title="Print mode", dest="print_mode", required=True)
     label = print_modes.add_parser(
         "label", help="Configure printables", argument_default=argparse.SUPPRESS)
+    label_file = print_modes.add_parser(
+        "file", help="Open predefined label file that was generate from the UI")
 
     ### the printables arguments
     label.add_argument("-t", "--text", type=str, action=OrderArguments)
@@ -85,6 +87,10 @@ def get_parser():
     label.add_argument("-b", "--barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
     label.add_argument("-l", "--labeled-barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
     label.add_argument("-i", "--image", type=tuple_type_factory([str, int]), action=OrderArguments)
+
+    ## add argument for label file
+    label_file.add_argument("label_file_name", type=str)
+
 
     return parser
 

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -1,0 +1,103 @@
+from argparse import ArgumentParser, _ArgumentGroup as ArgumentGroup
+import argparse
+from typing import List, Tuple
+import re
+from dataclasses import fields, MISSING
+
+
+from labelmaker.config import LabelMakerConfig
+
+
+class OrderArguments(argparse.Action):
+    def __call__(self, _parser, namespace, values, _option_string=None):
+        if not 'ordered_printables' in namespace:
+            setattr(namespace, 'ordered_printables', [])
+        previous = namespace.ordered_printables
+        previous.append((self.dest, values))
+
+
+def tuple_type_factory(types: List, delimiter: str = ":"):
+    import csv
+    def tuple_parser(text: str) -> Tuple:
+        data = next(csv.reader(
+            [text], delimiter=delimiter, quotechar='"', 
+            doublequote=True,strict=True, escapechar="\\"))
+        assert len(types) == len(data), f"{text} (parsed: {data}) doesn't have {len(types)} arguments"
+        for i, t in enumerate(types):
+            data[i] = t(data[i])
+        return tuple(data)
+    return tuple_parser
+
+
+def sanitize_python(name: str) -> str:
+    return name.replace("_", "-")
+
+
+def cli_setup_labelmakerconfig(parser: ArgumentGroup, dataclass):
+    for field in fields(dataclass):
+        assert field.default_factory == MISSING, f"{field.name} should not use a default factory"
+
+        further_args = {
+            "dest": f"{dataclass.__name__}|{field.name}",
+            "type": str if type(field.type) != type else field.type,
+            "required": field.default == MISSING,
+        }
+
+        if field.default != MISSING:
+
+            if field.type == bool:
+                further_args["action"] = "store_" + ("true" if not field.default else "false")
+                del further_args["type"]
+            else:
+                further_args["default"] = field.default 
+
+        parser.add_argument(
+            f"--{sanitize_python(field.name)}", **further_args)
+
+
+def get_parser():
+    parser = ArgumentParser(description="Utility to print to the Brother P-Touch Cube system")
+    runtime = parser.add_subparsers(title="Runtime mode", dest="runtime", required=False)
+    runtime.default = "gui"
+    gui = runtime.add_parser("gui", help="Use the utlity in GUI mode")
+    cli = runtime.add_parser("print", help="Print using suplied arguments")
+
+    ## configure gui parser
+    gui.add_argument("--seed", help="Setup the GUI with example printables", action="store_true")
+    
+    ## configure cli
+    ### setup possible configuration parameters
+    config = cli.add_argument_group('config')
+    cli_setup_labelmakerconfig(config, LabelMakerConfig)
+    config.add_argument("--default-font", type=str, default="auto")
+    config.add_argument("--device", type=str, default="auto")
+    config.add_argument("--output", type=str, help="don't print just write the output to a png")
+
+    ### define the print modes
+    print_modes = cli.add_subparsers(title="Print mode", dest="print_mode", required=True)
+    label = print_modes.add_parser(
+        "label", help="Configure printables", argument_default=argparse.SUPPRESS)
+
+    ### the printables arguments
+    label.add_argument("-t", "--text", type=str, action=OrderArguments)
+    label.add_argument("-q", "--qr-code", type=str, action=OrderArguments)
+    label.add_argument("-s", "--spacing", type=int, action=OrderArguments)
+    label.add_argument("-b", "--barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
+    label.add_argument("-l", "--labeled-barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
+    label.add_argument("-i", "--image", type=tuple_type_factory([str, int]), action=OrderArguments)
+
+    return parser
+
+
+##############
+## Parsers  ##
+##############
+
+def dataclass_from_args(args: argparse.Namespace, dataclass):
+    dc_args = {
+        s[1]: getattr(args, k) for k in dir(args) 
+        if (s := k.split("|"))[0] == dataclass.__name__
+    }
+
+    return dataclass(**dc_args)
+

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -92,7 +92,7 @@ def get_parser():
         "-s", "--spacing", help="Adds spacing. Argument should be int",
         type=int, action=OrderArguments)
     label.add_argument(
-        "-b", "--barcode", help="Add barcode delimited with ':' in the format DATA:BARCODE_TYPE"
+        "-b", "--barcode", help="Add barcode delimited with ':' in the format DATA:BARCODE_TYPE",
         type=tuple_type_factory([str,str]), action=OrderArguments)
     label.add_argument(
         "-l", "--labeled-barcode", help="Add barcode with label. See --barcode",

--- a/cli/arguments.py
+++ b/cli/arguments.py
@@ -76,20 +76,35 @@ def get_parser():
     ### define the print modes
     print_modes = cli.add_subparsers(title="Print mode", dest="print_mode", required=True)
     label = print_modes.add_parser(
-        "label", help="Configure printables", argument_default=argparse.SUPPRESS)
+        "label", help="Configure printables. Order is preserved", 
+        argument_default=argparse.SUPPRESS)
     label_file = print_modes.add_parser(
         "file", help="Open predefined label file that was generate from the UI")
 
     ### the printables arguments
-    label.add_argument("-t", "--text", type=str, action=OrderArguments)
-    label.add_argument("-q", "--qr-code", type=str, action=OrderArguments)
-    label.add_argument("-s", "--spacing", type=int, action=OrderArguments)
-    label.add_argument("-b", "--barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
-    label.add_argument("-l", "--labeled-barcode", type=tuple_type_factory([str,str]), action=OrderArguments)
-    label.add_argument("-i", "--image", type=tuple_type_factory([str, int]), action=OrderArguments)
+    label.add_argument(
+        "-t", "--text", help="Text to write. Font is taken from --default-font",
+        type=str, action=OrderArguments)
+    label.add_argument(
+        "-q", "--qr-code", help="Argument is the qr-code data",
+        type=str, action=OrderArguments)
+    label.add_argument(
+        "-s", "--spacing", help="Adds spacing. Argument should be int",
+        type=int, action=OrderArguments)
+    label.add_argument(
+        "-b", "--barcode", help="Add barcode delimited with ':' in the format DATA:BARCODE_TYPE"
+        type=tuple_type_factory([str,str]), action=OrderArguments)
+    label.add_argument(
+        "-l", "--labeled-barcode", help="Add barcode with label. See --barcode",
+        type=tuple_type_factory([str,str]), action=OrderArguments)
+    label.add_argument(
+        "-i", "--image", help="Adds an image with format IMAGE_PATH:THRESHOLD. Where threshold is an int",
+        type=tuple_type_factory([str, int]), action=OrderArguments)
 
     ## add argument for label file
-    label_file.add_argument("label_file_name", type=str)
+    label_file.add_argument(
+        "label_file_name", help="File path to label project file",
+        type=str)
 
 
     return parser

--- a/cli/cli_print.py
+++ b/cli/cli_print.py
@@ -49,6 +49,8 @@ class CliPrint:
 
     def print(self):
         self.editor.update_preview()
+
+        assert self.editor.print_image is not None, "Unable to generate printable image"
        
         if not self.ignore_printer:
           thread = PrintThread(
@@ -61,6 +63,10 @@ class CliPrint:
     def set_output_only(self, output: Optional[str]):
         self.output = output
         self.ignore_printer = output is not None
+
+    def open_file(self, file: str):
+        self.editor.current_file = file
+        self.editor.open()
 
     @staticmethod
     def _calculate_text_properties(font_name):
@@ -119,8 +125,15 @@ class CliPrint:
 
         config = dataclass_from_args(args, LabelMakerConfig)
         cli.set_label_maker_config(config)
-        cli.printables_from_args(args)
         cli.set_output_only(args.output)
+
+        match args.print_mode:
+            case "label":
+                cli.printables_from_args(args)
+            case "file":
+                cli.open_file(args.label_file_name)
+            case _:
+                raise NotImplementedError(f"{args.print_mode}")
 
         return cli
 

--- a/cli/cli_print.py
+++ b/cli/cli_print.py
@@ -1,0 +1,131 @@
+from argparse import Namespace
+from typing import List, Tuple, Any, Optional
+import logging
+
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtGui import QImage, QFont, QFontMetrics
+
+from .arguments import dataclass_from_args
+from printables.printable import Printable
+from labelmaker.comms import SerialPrinterDevice
+from labelmaker.config import LabelMakerConfig
+from gui.editor_window import EditorWindow
+from print_thread import PrintThread
+
+from margins import Margins
+from printables.printable import Printable
+from printables.text import TextData, Text, TextPropsEdit
+from printables.qrcode import QrCode, QrCodeData
+from printables.spacing import Spacing, SpacingData
+from printables.barcode import Barcode, BarcodeData
+from printables.image import Image, ImageData
+
+class CliPrint:
+    def __init__(self, device: str):
+        self.set_device(device)
+        self.app = QApplication([])
+        self.editor = EditorWindow(self.app)
+        self.label_config = None
+        self.output = None
+        self.ignore_printer = False
+
+        logging.root.addHandler(logging.StreamHandler())
+        logging.root.setLevel(logging.INFO)
+
+    def set_device(self, device: str):
+        if device == "auto":
+            dev = SerialPrinterDevice(SerialPrinterDevice.list_comports()[0])
+        else:
+            dev =  SerialPrinterDevice.find(device)
+            assert dev is not None, "Could not find device"
+
+        self.device = dev
+
+    def set_label_maker_config(self, config: LabelMakerConfig):
+        self.label_config = config
+
+    def add_printable(self, printable: Printable):
+        self.editor.sources.add_item(printable)
+
+    def print(self):
+        self.editor.update_preview()
+       
+        if not self.ignore_printer:
+          thread = PrintThread(
+              QImage(self.editor.print_image), self.device, 
+              self.label_config)
+          thread.run()
+        if self.output is not None:
+            self.editor.print_image.save(self.output)
+
+    def set_output_only(self, output: Optional[str]):
+        self.output = output
+        self.ignore_printer = output is not None
+
+    @staticmethod
+    def _calculate_text_properties(font_name):
+        """Method to calculate text properties so that the text is fully visible
+        This means that the text is center vertically in accordance to the cap height"""
+
+        font = QFont(font_name)
+        font_size = 68
+
+        adjusted_font_size = TextPropsEdit.calc_adjusted_size_for_font(font, font_size)
+        font.setPixelSize(adjusted_font_size)
+
+        # calculate top margin
+        font_metric = QFontMetrics(font)
+        # as text is rendered so that the heighest position the font can reach
+        # is visible (ascent), we need to remove the space between that and 
+        # the heighest position a normal capital letter would reach. (capHeight)
+        top_margin = font_metric.capHeight() - font_metric.ascent()
+
+        # without this line the font is glued to the top of all capitals
+        # so now we can calculate the margin that would center the capHeight
+        top_margin += (68 - font_metric.capHeight()) // 2
+    
+        return font, top_margin
+
+    def printables_from_args(self, cli_args: Namespace):
+        printable_args: List[Tuple[str, Any]] = cli_args.ordered_printables
+        font = cli_args.default_font
+
+        for (name, args) in printable_args:
+            tmp = None
+            match name:
+                case "text":
+                    font, vert_margin = self._calculate_text_properties(font)
+                    margin = Margins(vert=vert_margin)
+                    tmp = Text(TextData(args, font.toString(), margin))
+                case "qr_code":
+                    tmp = QrCode(QrCodeData(args))
+                case "spacing":
+                    tmp = Spacing(SpacingData(args))
+                case name if "barcode" in name:
+                    has_label = "label" in name
+                    text, code_type = args
+                    tmp = Barcode(BarcodeData(None, text, code_type, has_label))
+                case "image":
+                    image_source, threshold = args
+                    tmp = Image(ImageData(image_source, int(threshold)))
+
+            assert tmp != None
+            self.add_printable(tmp)
+            
+
+    @classmethod
+    def create(cls, args: Namespace) -> 'CliPrint':
+        cli = cls(args.device)
+
+        config = dataclass_from_args(args, LabelMakerConfig)
+        cli.set_label_maker_config(config)
+        cli.printables_from_args(args)
+        cli.set_output_only(args.output)
+
+        return cli
+
+    @classmethod
+    def run(cls, args: Namespace):
+        cli = cls.create(args)
+        cli.print()
+

--- a/gui/editor_window.py
+++ b/gui/editor_window.py
@@ -195,13 +195,13 @@ class EditorWindow(QMainWindow):
         file_path, file_format = QFileDialog.getSaveFileName(
             self,
             caption='Save Label',
-            directory=save_initial_path,
+            directory=save_initial_path + "/mylabel.p3label",
             filter='Label Files (*.p3label)')
 
         if len(file_path) <= 0:
             return
 
-        self.current_file = file_path
+        self.current_file = str(file_path)
         self.save()
 
     def on_export(self):
@@ -232,7 +232,8 @@ class EditorWindow(QMainWindow):
             self,
             caption='Open Label',
             directory=open_initial_path,
-            filter='Label Files (*.p3label)')
+            filter='All (*);;Label Files (*.p3label)',
+            initialFilter="Label Files (*.p3label)")
 
         if len(file_path) <= 0:
             return

--- a/labelmaker/config.py
+++ b/labelmaker/config.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, asdict
+from typing import Callable
+
+@dataclass
+class LabelMakerConfig:
+    mirror_printing: bool = False
+    auto_tape_cut: bool = False
+
+    """Warn: Only effective with laminated tape"""
+    half_cut: bool = False
+
+    """When printing multiple copies, the labels are fed after the last one is printed."""
+    chain_print: bool = False
+
+    """When printing multiple copies, the end of the last label is cut."""
+    label_end_cut: bool = False
+
+    """High resolution printing"""
+    high_res_print: bool = False
+    
+    """No buffer clearing when printing (inverted)
+    The expansion buffer of the P-touch is not cleared with the “no buffer 
+    clearing when printing” command. If this command is sent when the data 
+    of the first label is printed (it is specified between the “initialize”
+    command and the print data), printing is possible only if a print command 
+    is sent with the second or later label. However, this is possible only when 
+    printing extremely small labels.
+    """
+    clear_buf: bool = True
+
+    margin: int = 0
+
+
+    def apply(self, fun: Callable):
+        available_paras = set(fun.__code__.co_varnames)
+        para_dict = {k: v for k, v in asdict(self).items() if k in available_paras}
+        return fun(**para_dict)
+

--- a/print_thread.py
+++ b/print_thread.py
@@ -3,7 +3,9 @@ import traceback
 
 from PyQt6.QtCore import QThread, pyqtSignal
 
+from typing import Optional
 from labelmaker import LabelMaker, BUFFER_HEIGHT, PRINT_MARGIN
+from labelmaker.config import LabelMakerConfig
 
 log = logging.getLogger(__name__)
 
@@ -12,8 +14,9 @@ class PrintThread(QThread):
     done = pyqtSignal('PyQt_PyObject')
     log = pyqtSignal('PyQt_PyObject')
 
-    def __init__(self, print_image, print_device):
+    def __init__(self, print_image, print_device, config: Optional[LabelMakerConfig] = None):
         QThread.__init__(self)
+        self.config = config
         self.print_image = print_image
         self.print_device = print_device
 
@@ -53,7 +56,7 @@ class PrintThread(QThread):
             log.info(
                 'Printing label, width: {0} height: {1}'.format(self.print_image.width(), self.print_image.height()))
 
-            lm = LabelMaker(self.print_device)
+            lm = LabelMaker(self.print_device, self.config)
             lm.print_label(buf)
             #self.print_device.test()
             self.done.emit(None)

--- a/printables/qrcode.py
+++ b/printables/qrcode.py
@@ -1,4 +1,5 @@
 import math
+from typing import Optional
 
 import qrcode
 from PyQt6.QtGui import QImage, QPainter, QColor
@@ -36,9 +37,12 @@ class QrCodePropsEdit(PropsEdit):
 
 
 class QrCode(Printable):
-    def __init__(self):
+    def __init__(self, data: Optional[QrCodeData] = None):
         super().__init__()
-        self.data = QrCodeData()
+        if data is None:
+            data = QrCodeData()
+
+        self.data = data
 
     def get_margins(self):
         return self.data.margins

--- a/pytouch3.py
+++ b/pytouch3.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import sys
 import os.path as path
-from sys import argv
 
 from PyQt6.QtWidgets import QApplication
 from qasync import QEventLoop
@@ -13,13 +12,12 @@ from printables.barcode import BarcodeData, Barcode
 from printables.spacing import Spacing, SpacingData
 from printables.text import TextData, Text as TextItem
 from printables.image import ImageData, Image as ImageItem
+from cli import get_parser, CliPrint
 
 testdata = path.join(path.dirname(__file__) + '/testdata/')
 
 if not sys.gettrace() is None:
-    logging.basicConfig(level=logging.DEBUG
-
-                        )
+    logging.basicConfig(level=logging.DEBUG)
 
 
 def run(seed=False):
@@ -50,5 +48,14 @@ def run(seed=False):
         loop.run_forever()
 
 
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    if args.runtime == "gui":
+        run("seed" in args and args.seed)
+    else:
+        CliPrint.run(args)
+
+
 if __name__ == '__main__':
-    run(seed='--seed' in argv)
+    main()


### PR DESCRIPTION
Integrated a fully fledged CLI that will not start the GUI. 
One can configure special parameters like chained printing with it. 
Either print a previously generated p3label project file or completely design 
your own label (with a few limitations)

Starting GUI can be done by either
`pytouch3 gui` or just normal `pytouch3`

Limitations to designing own file:
1. cannot specify margin
2. fonts are scaled to center in the label - cannot declare font size
3. otherwise everything should work

```
usage: pytouch3.py [-h] {gui,print} ...

Utility to print to the Brother P-Touch Cube system

options:
  -h, --help   show this help message and exit

Runtime mode:
  {gui,print}
    gui        Use the utlity in GUI mode
    print      Print using suplied arguments

### python3 pytouch3.py gui --help
options:
  -h, --help  show this help message and exit
  --seed      Setup the GUI with example printables

### python3 pytouch3.py print --help
usage: pytouch3.py print [-h] [--mirror-printing] [--auto-tape-cut]
                         [--half-cut] [--chain-print] [--label-end-cut]
                         [--high-res-print] [--clear-buf]
                         [--margin LABELMAKERCONFIG|MARGIN]
                         [--default-font DEFAULT_FONT] [--device DEVICE]
                         [--output OUTPUT]
                         {label,file} ...

options:
  -h, --help            show this help message and exit

config:
  --mirror-printing
  --auto-tape-cut
  --half-cut
  --chain-print
  --label-end-cut
  --high-res-print
  --clear-buf
  --margin LABELMAKERCONFIG|MARGIN
  --default-font DEFAULT_FONT
  --device DEVICE
  --output OUTPUT       don't print just write the output to a png

Print mode:
  {label,file}
    label               Configure printables. Order is preserved
    file                Open predefined label file that was generate from
                        the UI

### pytouch3 print label --help
usage: pytouch3.py print label [-h] [-t TEXT] [-q QR_CODE] [-s SPACING]
                               [-b BARCODE] [-l LABELED_BARCODE]
                               [-i IMAGE]

options:
  -h, --help            show this help message and exit
  -t TEXT, --text TEXT  Text to write. Font is taken from --default-font
  -q QR_CODE, --qr-code QR_CODE
                        Argument is the qr-code data
  -s SPACING, --spacing SPACING
                        Adds spacing. Argument should be int
  -b BARCODE, --barcode BARCODE
                        Add barcode delimited with ':' in the format
                        DATA:BARCODE_TYPE
  -l LABELED_BARCODE, --labeled-barcode LABELED_BARCODE
                        Add barcode with label. See --barcode
  -i IMAGE, --image IMAGE
                        Adds an image with format IMAGE_PATH:THRESHOLD.
                        Where threshold is an int

### pytouch print file --help
usage: pytouch3.py print file [-h] label_file_name

positional arguments:
  label_file_name

options:
  -h, --help       show this help message and exit
```