### PR TITLE
docs: update dependencies for python 3.10 @ ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,29 @@
 Qt5 Label Editor for Brother P-Touch Cube label maker.  
 Forked from [this gist by @stecman](https://gist.github.com/stecman/ee1fd9a8b1b6f0fdd170ee87ba2ddafd)
 
+# Installation note:
+To install the dependencies into a virtual env run
+```
+python3 -m venv venv
+. venv/bin/activate
+```
 
+PyBluez 0.23 in Version is incompatible with setuptools >=58.0.0
+Downgrade setuptools first with
+```
+python3 -m pip install setuptools==57.0.0
+```
+
+Then install the dependencies with
+```
+python3 -m pip install -r requirements.txt
+```
+
+and run the app with
+
+```
+python3 pytouch.py
+```
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==57.0.0
 PyQt6>=6.3
 django-qrcode~=0.3
 pyserial~=3.4
@@ -7,6 +8,6 @@ appdirs~=1.4.4
 pyyaml~=5.4.0
 qrcode~=6.1
 qasync~=0.23.0
-setuptools~=41.2.0
 altgraph~=0.17
 pybluez~=0.23
+pyyaml

--- a/settings.py
+++ b/settings.py
@@ -37,11 +37,11 @@ class Settings:
 
         config_dir = ad.user_config_dir
         if not os.path.isdir(config_dir):
-            os.mkdirs(config_dir)
+            os.makedirs(config_dir)
 
         defaults_dir = os.path.join(config_dir, 'defaults')
         if not os.path.isdir(defaults_dir):
-            os.mkdirs(defaults_dir)
+            os.makedirs(defaults_dir)
 
         file_path = os.path.join(config_dir, 'settings.yml')
 


### PR DESCRIPTION
The bluez version 0.23 is incombatible to setuptools >=58.0.0.
Ubuntu 22.04 ships 59.6.0 which leads to pybluez not building
anymore.

Furthermore mkdirs is no longer available on modern python3 including
the latest python 3.10.5. We therefore replace it with makedirs.

As a last step we need pyyaml in our requirements as it is not installed
by default into the python distributions.

We document the steps to create a virtual environment in the README for
the next person to find themself with a modern python (¬_¬)

Signed-off-by: Mimoja <git@mimoja.de>