### PR TITLE
feat(printables): allow spacing to fill 999 pixels instead of 99

### DIFF
--- a/printables/spacing.py
+++ b/printables/spacing.py
@@ -34,6 +34,7 @@ class SpacingPropsEdit(PropsEdit):
 
         self.edit_width = QSpinBox(self)
         self.edit_width.setValue(self.data.width)
+        self.edit_width.setMaximum(999)
         self.layout.addWidget(QLabel('Width:'))
         self.layout.addWidget(self.edit_width)
         self.edit_width.valueChanged.connect(self.on_width_changed)


### PR DESCRIPTION
QSpinBox defaults to 100 values between 0 and 99.
By explicitly setting a maximum we allow a wider spacing
without an limitation that is not really engrained in the printer
or the app.

Setting the maxiumum to 999; This 'ought to be enough for anybody'.

Signed-off-by: Mimoja <git@mimoja.de>