### PR TITLE
build(deps): pin first pybluez version that is compatible with modern SetupTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,7 @@ To install the dependencies into a virtual env run
 python3 -m venv venv
 . venv/bin/activate
 ```
-
-PyBluez 0.23 in Version is incompatible with setuptools >=58.0.0
-Downgrade setuptools first with
-```
-python3 -m pip install setuptools==57.0.0
-```
-
-Then install the dependencies with
+Install the dependencies with
 ```
 python3 -m pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools==57.0.0
 PyQt6>=6.3
 django-qrcode~=0.3
 pyserial~=3.4
@@ -9,5 +8,5 @@ pyyaml~=5.4.0
 qrcode~=6.1
 qasync~=0.23.0
 altgraph~=0.17
-pybluez~=0.23
+git+https://github.com/pybluez/pybluez.git@37d7888#egg=pybluez; sys_platform == 'linux'
 pyyaml


### PR DESCRIPTION
PyBluez is already aware of the issue that SetupTools no longer
supports "use_2to3".
https://github.com/pybluez/pybluez/issues/413
And fixed already in September 2021 in:
https://github.com/pybluez/pybluez/commit/37d78880179b2a83e7052e0c2b9393499dd3b857
Sadly there is currently no new pypi release since 2019 so there is no
tagged release for us to upgrade to.
https://github.com/pybluez/pybluez/issues/416
This is due to the lack of a pybluez maintainer
https://github.com/pybluez/pybluez/issues/411

To solve this we are pinning the commit that removed the use_2to3
in the requirements.txt allowing us to build with moden python distributions.

Testing done: Printed one Label with text and spacing

We are also only pulling in pybluez on linux as it wont work on windows and macos.
Fixes: 20f11b082eeafc6367c0043c6c5dac8c27bc2a4b Transition to qt6 (#29)

Signed-off-by: Mimoja <git@mimoja.de>