### PR TITLE
build(deps): remove duplicate pyyaml from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ To install the dependencies into a virtual env run
 python3 -m venv venv
 . venv/bin/activate
 ```
+
+On Ubuntu 20.04 the pip3 version shipped is not able to install pyQt6. You might need to upgrade pip first.
+```
+pip install pip --upgrade
+```
+
 Install the dependencies with
 ```
 python3 -m pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -13,14 +13,7 @@ To install the dependencies into a virtual env run
 python3 -m venv venv
 . venv/bin/activate
 ```
-
-PyBluez 0.23 in Version is incompatible with setuptools >=58.0.0
-Downgrade setuptools first with
-```
-python3 -m pip install setuptools==57.0.0
-```
-
-Then install the dependencies with
+Install the dependencies with
 ```
 python3 -m pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools==57.0.0
 PyQt6>=6.3
 django-qrcode~=0.3
 pyserial~=3.4
@@ -9,5 +8,5 @@ pyyaml~=5.4.0
 qrcode~=6.1
 qasync~=0.23.0
 altgraph~=0.17
-pybluez~=0.23
+git+https://github.com/pybluez/pybluez.git@37d7888#egg=pybluez; sys_platform == 'linux'
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ qrcode~=6.1
 qasync~=0.23.0
 altgraph~=0.17
 git+https://github.com/pybluez/pybluez.git@37d7888#egg=pybluez; sys_platform == 'linux'
-pyyaml


### PR DESCRIPTION
While modern pip3 versions are absolutely okay with an double entry
if only one refers to a version, the python3.8 shipped pip3 from
ubuntu 20.04 does fail in this case very much.

```
ERROR: Double requirement given: pyyaml (from -r requirements.txt (line 13)) (already in pyyaml~=5.4.0 (from -r requirements.txt (line 8)), name='pyyaml')
```

Signed-off-by: Mimoja <git@mimoja.de>